### PR TITLE
Refactor predicates argument to semantic_jaccard_similarity() to be optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "rustsim"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "csv",
  "dict",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustsim"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ fn semantic_jaccard_similarity(
     closure_table: HashMap<String, HashMap<String, HashSet<String>>>,
     entity1: String,
     entity2: String,
-    predicates: HashSet<String>,
+    predicates: Option<HashSet<String>>,
 ) -> PyResult<f64> {
     Ok(calculate_semantic_jaccard_similarity(
         &closure_table,

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -6,7 +6,7 @@ pub fn calculate_semantic_jaccard_similarity(
     closure_table: &HashMap<String, HashMap<String, HashSet<String>>>,
     entity1: String,
     entity2: String,
-    predicates: &HashSet<String>,
+    predicates: &Option<HashSet<String>>,
 ) -> f64 {
     /* Returns semantic Jaccard similarity between the two sets. */
     let entity1_closure = expand_term_using_closure(&entity1, &closure_table, &predicates);
@@ -125,7 +125,7 @@ mod tests {
             &closure_table,
             String::from("CARO:0000000"),
             String::from("BFO:0000002"),
-            &sco_predicate,
+            &Some(sco_predicate.clone()),
         );
         println!("{result}");
         assert_eq!(result, 2.0 / 3.0);
@@ -134,7 +134,7 @@ mod tests {
             &closure_table,
             String::from("BFO:0000002"),
             String::from("BFO:0000003"),
-            &sco_predicate,
+            &Some(sco_predicate.clone()),
         );
         println!("{result2}");
         assert_eq!(result2, 0.5);
@@ -147,7 +147,7 @@ mod tests {
             &closure_table,
             String::from("BFO:0000002"),
             String::from("BFO:0000003"),
-            &sco_po_predicate,
+            &Some(sco_po_predicate.clone()),
         );
         println!("{result3}");
         assert_eq!(result3, 1.0 / 3.0);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -78,13 +78,20 @@ pub fn convert_list_of_tuples_to_hashmap(
 pub fn expand_term_using_closure(
     term: &String,
     closure_table: &HashMap<String, HashMap<String, HashSet<String>>>,
-    predicates: &HashSet<String>,
+    predicates: &Option<HashSet<String>>,
 ) -> HashSet<String> {
     let mut closure: HashSet<String> = HashSet::new();
     if let Some(term_closure) = closure_table.get(term) {
-        for pred in predicates {
-            if let Some(closure_terms) = term_closure.get(pred) {
+        if predicates.is_none() {
+            for (_, closure_terms) in term_closure {
                 closure.extend(closure_terms.iter().map(|s| s.to_owned()));
+            }
+        }
+        else {
+            for pred in predicates.as_ref().unwrap() {
+                if let Some(closure_terms) = term_closure.get(pred) {
+                    closure.extend(closure_terms.iter().map(|s| s.to_owned()));
+                }
             }
         }
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -38,7 +38,7 @@ fn integration_test_semantic_jaccard_similarity() {
         &closure_table,
         "apple".to_string(),
         "cherry".to_string(),
-        &HashSet::from(["is_a".to_string()]),
+        &Some(HashSet::from(["is_a".to_string()])),
     );
 
     assert_eq!(sem_jaccard, 0.5)


### PR DESCRIPTION
If pedicates is none, then compute predicates in Rust (should be faster)