### PR TITLE
Move counting of term frequencies to function `relationships_to_closure_table()` that makes closure table

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ fn max_information_content(
 #[pyfunction]
 fn relationships_to_closure_table(
     list_of_tuples: Vec<(String, String, String)>,
-) -> PyResult<HashMap<String, HashMap<String, HashSet<String>>>> {
+) -> PyResult<(HashMap<String, HashMap<String, HashSet<String>>>, HashMap<String, usize>)> {
     Ok(convert_list_of_tuples_to_hashmap(list_of_tuples))
 }
 


### PR DESCRIPTION
Move counting of frequencies to function `relationships_to_closure_table()` that makes closure table, instead of doing it on the fly in every entity1/entity2 comparison in `calculate_information_content_scores()`